### PR TITLE
Let Apache Listen Selectively

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ managing ssl.
 ```puppet
   # configure the global apache
   class { 'apache':
-    ensure       => running,
+    start        => true,
     enable       => true,
     server_admin => 'webmaster@example.com',
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,8 @@
 class apache::config {
   $config_template = $apache::params::config_template
   $config_file = $apache::params::config_file
+  validate_array($apache::listen_ips)
+  $listen_ipaddrs = $apache::listen_ips
 
   file { $conf_d_dir:
     ensure  => 'directory',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,10 +25,18 @@
 #  Usage:
 #     start = '<true|false|noop>'
 #
+# [*listen_ips*]
+#   The IP addresses puppet should configure apache to listen on. Provide as an
+#   array. The default will have Apache listen on all configured IP addresses.
+#
+#  Usage:
+#     listen_ips = ['127.0.0.1', ...]
+#
 class apache(
   $enable = $apache::params::enable,
   $server_admin = $apache::params::server_admin,
   $start = $apache::params::start,
+  $listen_ips = $apache::params::listen_ips,
 ) inherits apache::params {
   class { 'apache::install': } ->
   class { 'apache::config': } ~>

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -5,13 +5,16 @@
 class apache::mod::ssl {
   include apache::params
 
+  validate_array($apache::listen_ips)
+  $listen_ipaddrs = $apache::listen_ips
+
   package { 'mod_ssl': ensure => 'installed' }
 
   file { "${apache::params::conf_d_dir}/ssl.conf":
     owner  => 'root',
     group  => 'root',
     mode   => '0444',
-    source => 'puppet:///apache/ssl.conf',
+    content => template('apache/ssl.conf.erb'),
   }
 
   file { "${apache::params::conf_d_dir}/module-ssl.conf":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class apache::params {
   $ssl = false
   $ssl_cert_resource = 'UNSET'
   $provide_include = true
+  $listen_ips = []
 
   # DISTRO/VERSION DEPENDANT PARAMETER LOGIC
 

--- a/templates/httpd.conf.erb.el6
+++ b/templates/httpd.conf.erb.el6
@@ -133,7 +133,13 @@ MaxRequestsPerChild  0
 # prevent Apache from glomming onto all bound IP addresses (0.0.0.0)
 #
 #Listen 12.34.56.78:80
+<% if @listen_ipaddrs.kind_of? Array and @listen_ipaddrs.count > 0 then -%>
+<% @listen_ipaddrs.each do |ip| -%>
+Listen <%= ip %>:80
+<% end -%>
+<% else -%>
 Listen 80
+<% end -%>
 
 #
 # Dynamic Shared Object (DSO) Support

--- a/templates/ssl.conf.erb
+++ b/templates/ssl.conf.erb
@@ -1,0 +1,51 @@
+# Managed by Puppet (<%= @name %>)
+#
+LoadModule ssl_module modules/mod_ssl.so
+
+#
+# When we also provide SSL we have to listen to the 
+# the HTTPS port in addition.
+#
+<% if @listen_ipaddrs.kind_of? Array and @listen_ipaddrs.count > 0 -%>
+<% @listen_ipaddrs.each do |ip| -%>
+Listen <%= ip %>:443
+<% end -%>
+<% else -%>
+Listen 443
+<% end -%>
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is a internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog  builtin
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism 
+#   to use and second the expiring timeout (in seconds).
+SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
+SSLSessionCacheTimeout  300
+
+#   Semaphore:
+#   Configure the path to the mutual exclusion semaphore the
+#   SSL engine uses internally for inter-process synchronization. 
+SSLMutex default
+
+SSLRandomSeed startup file:/dev/urandom  256
+SSLRandomSeed connect builtin
+
+#
+# Use "SSLCryptoDevice" to enable any supported hardware
+# accelerators. Use "openssl engine -v" to list supported
+# engine names.  NOTE: If you enable an accelerator and the
+# server does not start, consult the error logs and ensure
+# your accelerator is functioning properly. 
+#
+SSLCryptoDevice builtin


### PR DESCRIPTION
For hosts with multiple IP addresses, Apache may need to be stopped from binding to all available addresses.
